### PR TITLE
Ethereum deployments for basic module set

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1789,6 +1789,7 @@
       "deployments": [
         { "chainId": "5", "block": "9608205" },
         { "chainId": "11155111", "block": "4655335" },
+        { "chainId": "1", "block": "18936373" },
         { "chainId": "10", "block": "110684714" },
         { "chainId": "137", "block": "48563371" },
         { "chainId": "42161", "block": "139454273" },
@@ -1989,6 +1990,7 @@
       "deployments": [
         { "chainId": "5", "block": "9611056" },
         { "chainId": "11155111", "block": "4655367" },
+        { "chainId": "1", "block": "18936346" },
         { "chainId": "10", "block": "110684393" },
         { "chainId": "137", "block": "48563085" },
         { "chainId": "42161", "block": "139452101" },
@@ -2157,6 +2159,7 @@
       "deployments": [
         { "chainId": "5", "block": "9611065" },
         { "chainId": "11155111", "block": "4655346" },
+        { "chainId": "1", "block": "18936352" },
         { "chainId": "10", "block": "110684542" },
         { "chainId": "137", "block": "48563224" },
         { "chainId": "42161", "block": "139452888" },
@@ -2321,6 +2324,7 @@
       "deployments": [
         { "chainId": "5", "block": "9719807" },
         { "chainId": "11155111", "block": "4655381" },
+        { "chainId": "1", "block": "18936188" },
         { "chainId": "10", "block": "109769331" },
         { "chainId": "137", "block": "48562276" },
         { "chainId": "42161", "block": "139445749" },
@@ -3694,6 +3698,7 @@
       "deployments": [
         { "chainId": "5", "block": "9838324" },
         { "chainId": "11155111", "block": "4655455" },
+        { "chainId": "1", "block": "18936176" },
         { "chainId": "10", "block": "110683684" },
         { "chainId": "137", "block": "48562453" },
         { "chainId": "42161", "block": "139447326" },

--- a/modules/erc1155Eligibility.json
+++ b/modules/erc1155Eligibility.json
@@ -42,6 +42,10 @@
       "block": "4655335"
     },
     {
+      "chainId": "1",
+      "block": "18936373"
+    },
+    {
       "chainId": "10",
       "block": "110684714"
     },
@@ -109,13 +113,25 @@
   "abi": [
     {
       "inputs": [
-        { "internalType": "string", "name": "_version", "type": "string" }
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
     },
-    { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
-    { "inputs": [], "name": "NotInitializing", "type": "error" },
+    {
+      "inputs": [],
+      "name": "AlreadyInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotInitializing",
+      "type": "error"
+    },
     {
       "anonymous": false,
       "inputs": [
@@ -132,7 +148,13 @@
     {
       "inputs": [],
       "name": "ARRAY_LENGTH",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
@@ -140,7 +162,11 @@
       "inputs": [],
       "name": "HATS",
       "outputs": [
-        { "internalType": "contract IHats", "name": "", "type": "address" }
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "pure",
       "type": "function"
@@ -148,7 +174,13 @@
     {
       "inputs": [],
       "name": "IMPLEMENTATION",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
@@ -156,7 +188,11 @@
       "inputs": [],
       "name": "MIN_BALANCES",
       "outputs": [
-        { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+        {
+          "internalType": "uint256[]",
+          "name": "",
+          "type": "uint256[]"
+        }
       ],
       "stateMutability": "pure",
       "type": "function"
@@ -164,7 +200,13 @@
     {
       "inputs": [],
       "name": "TOKEN_ADDRESS",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
@@ -172,20 +214,40 @@
       "inputs": [],
       "name": "TOKEN_IDS",
       "outputs": [
-        { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+        {
+          "internalType": "uint256[]",
+          "name": "",
+          "type": "uint256[]"
+        }
       ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" },
-        { "internalType": "uint256", "name": "", "type": "uint256" }
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
       ],
       "name": "getWearerStatus",
       "outputs": [
-        { "internalType": "bool", "name": "eligible", "type": "bool" },
-        { "internalType": "bool", "name": "standing", "type": "bool" }
+        {
+          "internalType": "bool",
+          "name": "eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "standing",
+          "type": "bool"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -193,13 +255,23 @@
     {
       "inputs": [],
       "name": "hatId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
       ],
       "name": "setUp",
       "outputs": [],
@@ -209,14 +281,26 @@
     {
       "inputs": [],
       "name": "version",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "version_",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     }

--- a/modules/erc20Eligibility.json
+++ b/modules/erc20Eligibility.json
@@ -37,6 +37,10 @@
       "block": "4655367"
     },
     {
+      "chainId": "1",
+      "block": "18936346"
+    },
+    {
       "chainId": "10",
       "block": "110684393"
     },
@@ -90,13 +94,25 @@
   "abi": [
     {
       "inputs": [
-        { "internalType": "string", "name": "_version", "type": "string" }
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
     },
-    { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
-    { "inputs": [], "name": "NotInitializing", "type": "error" },
+    {
+      "inputs": [],
+      "name": "AlreadyInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotInitializing",
+      "type": "error"
+    },
     {
       "anonymous": false,
       "inputs": [
@@ -113,7 +129,13 @@
     {
       "inputs": [],
       "name": "ERC20_TOKEN_ADDRESS",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
@@ -121,7 +143,11 @@
       "inputs": [],
       "name": "HATS",
       "outputs": [
-        { "internalType": "contract IHats", "name": "", "type": "address" }
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "pure",
       "type": "function"
@@ -129,26 +155,54 @@
     {
       "inputs": [],
       "name": "IMPLEMENTATION",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "MIN_BALANCE",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" },
-        { "internalType": "uint256", "name": "", "type": "uint256" }
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
       ],
       "name": "getWearerStatus",
       "outputs": [
-        { "internalType": "bool", "name": "eligible", "type": "bool" },
-        { "internalType": "bool", "name": "standing", "type": "bool" }
+        {
+          "internalType": "bool",
+          "name": "eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "standing",
+          "type": "bool"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -156,13 +210,23 @@
     {
       "inputs": [],
       "name": "hatId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
       ],
       "name": "setUp",
       "outputs": [],
@@ -172,14 +236,26 @@
     {
       "inputs": [],
       "name": "version",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "version_",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     }

--- a/modules/erc721Eligibility.json
+++ b/modules/erc721Eligibility.json
@@ -37,6 +37,10 @@
       "block": "4655346"
     },
     {
+      "chainId": "1",
+      "block": "18936352"
+    },
+    {
       "chainId": "10",
       "block": "110684542"
     },
@@ -90,13 +94,25 @@
   "abi": [
     {
       "inputs": [
-        { "internalType": "string", "name": "_version", "type": "string" }
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
     },
-    { "inputs": [], "name": "AlreadyInitialized", "type": "error" },
-    { "inputs": [], "name": "NotInitializing", "type": "error" },
+    {
+      "inputs": [],
+      "name": "AlreadyInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotInitializing",
+      "type": "error"
+    },
     {
       "anonymous": false,
       "inputs": [
@@ -113,7 +129,13 @@
     {
       "inputs": [],
       "name": "ERC721_TOKEN_ADDRESS",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
@@ -121,7 +143,11 @@
       "inputs": [],
       "name": "HATS",
       "outputs": [
-        { "internalType": "contract IHats", "name": "", "type": "address" }
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "pure",
       "type": "function"
@@ -129,26 +155,54 @@
     {
       "inputs": [],
       "name": "IMPLEMENTATION",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "MIN_BALANCE",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" },
-        { "internalType": "uint256", "name": "", "type": "uint256" }
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
       ],
       "name": "getWearerStatus",
       "outputs": [
-        { "internalType": "bool", "name": "eligible", "type": "bool" },
-        { "internalType": "bool", "name": "standing", "type": "bool" }
+        {
+          "internalType": "bool",
+          "name": "eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "standing",
+          "type": "bool"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -156,13 +210,23 @@
     {
       "inputs": [],
       "name": "hatId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
       ],
       "name": "setUp",
       "outputs": [],
@@ -172,14 +236,26 @@
     {
       "inputs": [],
       "name": "version",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "version_",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     }

--- a/modules/hatWearingEligibility.json
+++ b/modules/hatWearingEligibility.json
@@ -33,6 +33,10 @@
       "block": "4655381"
     },
     {
+      "chainId": "1",
+      "block": "18936188"
+    },
+    {
       "chainId": "10",
       "block": "109769331"
     },
@@ -79,7 +83,11 @@
   "abi": [
     {
       "inputs": [
-        { "internalType": "string", "name": "_version", "type": "string" }
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
@@ -100,7 +108,13 @@
     {
       "inputs": [],
       "name": "CRITERION_HAT",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
@@ -108,7 +122,11 @@
       "inputs": [],
       "name": "HATS",
       "outputs": [
-        { "internalType": "contract IHats", "name": "", "type": "address" }
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "pure",
       "type": "function"
@@ -116,19 +134,41 @@
     {
       "inputs": [],
       "name": "IMPLEMENTATION",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" },
-        { "internalType": "uint256", "name": "", "type": "uint256" }
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
       ],
       "name": "getWearerStatus",
       "outputs": [
-        { "internalType": "bool", "name": "eligible", "type": "bool" },
-        { "internalType": "bool", "name": "standing", "type": "bool" }
+        {
+          "internalType": "bool",
+          "name": "eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "standing",
+          "type": "bool"
+        }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -136,13 +176,23 @@
     {
       "inputs": [],
       "name": "hatId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
       ],
       "name": "setUp",
       "outputs": [],
@@ -152,14 +202,26 @@
     {
       "inputs": [],
       "name": "version",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "version_",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     }

--- a/modules/passthroughEligibilityToggle.json
+++ b/modules/passthroughEligibilityToggle.json
@@ -33,6 +33,10 @@
       "block": "4655455"
     },
     {
+      "chainId": "1",
+      "block": "18936176"
+    },
+    {
       "chainId": "10",
       "block": "110683684"
     },
@@ -139,12 +143,20 @@
   "abi": [
     {
       "inputs": [
-        { "internalType": "string", "name": "_version", "type": "string" }
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
     },
-    { "inputs": [], "name": "NotAuthorized", "type": "error" },
+    {
+      "inputs": [],
+      "name": "NotAuthorized",
+      "type": "error"
+    },
     {
       "anonymous": false,
       "inputs": [
@@ -161,7 +173,13 @@
     {
       "inputs": [],
       "name": "CRITERION_HAT",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
@@ -169,7 +187,11 @@
       "inputs": [],
       "name": "HATS",
       "outputs": [
-        { "internalType": "contract IHats", "name": "", "type": "address" }
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
       ],
       "stateMutability": "pure",
       "type": "function"
@@ -177,21 +199,41 @@
     {
       "inputs": [],
       "name": "IMPLEMENTATION",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "hatId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        { "internalType": "uint256", "name": "_hatId", "type": "uint256" },
-        { "internalType": "bool", "name": "_newStatus", "type": "bool" }
+        {
+          "internalType": "uint256",
+          "name": "_hatId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "_newStatus",
+          "type": "bool"
+        }
       ],
       "name": "setHatStatus",
       "outputs": [],
@@ -200,10 +242,26 @@
     },
     {
       "inputs": [
-        { "internalType": "uint256", "name": "_hatId", "type": "uint256" },
-        { "internalType": "address", "name": "_wearer", "type": "address" },
-        { "internalType": "bool", "name": "_eligible", "type": "bool" },
-        { "internalType": "bool", "name": "_standing", "type": "bool" }
+        {
+          "internalType": "uint256",
+          "name": "_hatId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "_eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "_standing",
+          "type": "bool"
+        }
       ],
       "name": "setHatWearerStatus",
       "outputs": [],
@@ -212,7 +270,11 @@
     },
     {
       "inputs": [
-        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
       ],
       "name": "setUp",
       "outputs": [],
@@ -222,14 +284,26 @@
     {
       "inputs": [],
       "name": "version",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "version_",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
       "stateMutability": "view",
       "type": "function"
     }


### PR DESCRIPTION
Includes Ethereum mainnet deployments for the following modules:
- ERC20Eligibility
- ERC721Eligibility
- ERC1155Eligibility
- Passthrough
- HatWearingEligibility