### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Module Curation Managers have authority to review changes to the curation system, 
 # but not the items in the registry. See https://app.hatsprotocol.xyz/trees/10/1?hatId=1.2.4.5
 # Note that the last matching pattern takes the most precedence, so ownership of 
-# lines 8 and 9 falls exclusively to the Module Registry Curators
+# lines 9 and 10 falls exclusively to the Module Registry Curators
 *             @module-curation-managers
 
 # Module Registry Curators have authority to review submissions and changes to items 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Module Curation Managers have authority to review changes to the curation system, 
+# but not the items in the registry. See https://app.hatsprotocol.xyz/trees/10/1?hatId=1.2.4.5
+# Note that the last matching pattern takes the most precedence, so ownership of 
+# lines 8 and 9 falls exclusively to the Module Registry Curators
+*             @module-curation-managers
+
+# Module Registry Curators have authority to review submissions and changes to items 
+# in the registry, but not the curation system. See https://app.hatsprotocol.xyz/trees/10/1?hatId=1.2.4.4
+/modules/**   @modules-registry-curators
+/modules.json @modules-registry-curators

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Module Curation Managers have authority to review changes to the curation system, 
-# but not the items in the registry. See https://app.hatsprotocol.xyz/trees/10/1?hatId=1.2.4.5
+# but not the items in the registry. See https://app.hatsprotocol.xyz/trees/10/1?hatId=1.2.4.5.
 # Note that the last matching pattern takes the most precedence, so ownership of 
 # lines 9 and 10 falls exclusively to the Module Registry Curators
-*             @module-curation-managers
+*             @Hats-Protocol/module-curation-managers
 
 # Module Registry Curators have authority to review submissions and changes to items 
-# in the registry, but not the curation system. See https://app.hatsprotocol.xyz/trees/10/1?hatId=1.2.4.4
-/modules/**   @modules-registry-curators
-/modules.json @modules-registry-curators
+# in the registry, but not the curation system. See https://app.hatsprotocol.xyz/trees/10/1?hatId=1.2.4.4.
+/modules/**   @Hats-Protocol/modules-registry-curators
+/modules.json @Hats-Protocol/modules-registry-curators


### PR DESCRIPTION
Sets up code ownership to explicitly and separately grant review authorities:

- Modules Registry Curators: the registry itself, i.e. the new submissions and changes to items on the registry
- Module Curation Managers: the curation *system*, i.e. changes to everything else in the repo