### PR TITLE
Modules registry bot

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           yarn bundle
           yarn format-bundle
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name modules-registry-bot
+          git config user.email infra@hatsprotocol.xyz
           git add .
           git commit -m "automated bundle"
           git push

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MODULES_REGISTRY_BOT_TOKEN }}
       - name: Setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
The PR adds the modules-registry-bot's Github token secret to the bundling action, in order to provide it with the permission to bypass the branch protection rules. This bot is a Github account which was added to the repo as a member. 