### PR TITLE
Primary function prop for Agreement Eligibility roles

### DIFF
--- a/modules/AgreementEligibility.json
+++ b/modules/AgreementEligibility.json
@@ -135,6 +135,7 @@
       "functionName": "setAgreement",
       "label": "Set Agreement",
       "description": "Set a new agreement, with a grace period",
+      "primary": true,
       "args": [
         {
           "name": "Agreement",
@@ -155,6 +156,7 @@
       "functionName": "revoke",
       "label": "Revoke",
       "description": "Revoke the wearer's hat and place them in bad standing",
+      "primary": true,
       "args": [
         {
           "name": "Wearer",

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -20,7 +20,7 @@ describe("Schema Validation Tests", () => {
 
   beforeAll(async () => {
     anvil = createAnvil({
-      forkUrl: process.env.GOERLI_RPC,
+      forkUrl: process.env.SEPOLIA_RPC,
       startTimeout: 20000,
     });
     await anvil.start();


### PR DESCRIPTION
- Add the `primary` property for the Owner and Arbitrator roles of the Agreement Eligibility module. This prop is optional and indicates that the function is the primary action of the relevant role.
- Update the schema validation test to use the Sepolia instead of Goerli