### PR TITLE
Update agreement & allowlist modules with mutable roles

### DIFF
--- a/modules/AgreementEligibility.json
+++ b/modules/AgreementEligibility.json
@@ -22,12 +22,12 @@
     },
     {
       "label": "Owner Hat",
-      "functionName": "OWNER_HAT",
+      "functionName": "ownerHat",
       "displayType": "hat"
     },
     {
       "label": "Arbitrator Hat",
-      "functionName": "ARBITRATOR_HAT",
+      "functionName": "arbitratorHat",
       "displayType": "hat"
     }
   ],
@@ -36,40 +36,41 @@
     "toggle": false,
     "hatter": false
   },
-  "implementationAddress": "0xF6bc6Dd30403e6ff5b3Bebead32B8fce1b753aA1",
+  "implementationAddress": "0x8126d02F4EcDE43eca4543a0D90B755C3E225F09",
   "deployments": [
     {
       "chainId": "11155111",
-      "block": "5279344"
+      "block": "5906105"
     },
     {
       "chainId": "10",
-      "block": "116516227"
+      "block": "120018528"
     },
     {
       "chainId": "42161",
-      "block": "194358596"
+      "block": "210962674"
     },
     {
       "chainId": "100",
-      "block": "33122123"
+      "block": "33952979"
     },
     {
       "chainId": "42220",
-      "block": "24754861"
+      "block": "25593018"
     },
     {
       "chainId": "8453",
-      "block": "12327703"
+      "block": "14482815"
     },
     {
       "chainId": "137",
-      "block": "55094822"
+      "block": "56934657"
     }
   ],
   "creationArgs": {
     "useHatId": true,
-    "immutable": [
+    "immutable": [],
+    "mutable": [
       {
         "name": "Owner Hat",
         "description": "The hat ID for the owner hat. The wearer(s) of this hat are authorized to update the agreement.",
@@ -83,9 +84,7 @@
         "type": "uint256",
         "example": "26959946667150639794667015087019630673637144422540572481103610249216",
         "displayType": "hat"
-      }
-    ],
-    "mutable": [
+      },
       {
         "name": "Agreement",
         "description": "Initial agreement",
@@ -179,259 +178,464 @@
           "displayType": "default"
         }
       ]
+    },
+    {
+      "roles": ["agreementOwner"],
+      "functionName": "setOwnerHat",
+      "label": "Set Agreement Owner Hat",
+      "description": "Set the id of the agreement owner hat",
+      "args": [
+        {
+          "name": "New Agreement Owner Hat",
+          "description": "The id of the new agreement owner hat",
+          "type": "uint256",
+          "displayType": "hat"
+        }
+      ]
+    },
+    {
+      "roles": ["agreementOwner"],
+      "functionName": "setArbitratorHat",
+      "label": "Set Agreement Arbitrator Hat",
+      "description": "Set the id of the agreement arbitrator hat",
+      "args": [
+        {
+          "name": "New Agreement Arbitrator Hat",
+          "description": "The id of the new agreement arbitrator hat",
+          "type": "uint256",
+          "displayType": "hat"
+        }
+      ]
     }
   ],
   "abi": [
     {
-      "inputs": [
-        { "internalType": "string", "name": "_version", "type": "string" }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "constructor"
-    },
-    {
-      "inputs": [],
-      "name": "AgreementEligibility_NotArbitrator",
-      "type": "error"
-    },
-    { "inputs": [], "name": "AgreementEligibility_NotOwner", "type": "error" },
-    {
-      "anonymous": false,
+      "type": "constructor",
       "inputs": [
         {
-          "indexed": false,
-          "internalType": "string",
-          "name": "agreement",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "grace",
-          "type": "uint256"
+          "name": "_version",
+          "type": "string",
+          "internalType": "string"
         }
       ],
-      "name": "AgreementEligibility_AgreementSet",
-      "type": "event"
+      "stateMutability": "nonpayable"
     },
     {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "signer",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "agreement",
-          "type": "string"
-        }
-      ],
-      "name": "AgreementEligibility_AgreementSigned",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "claimer",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "hatId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "agreement",
-          "type": "string"
-        }
-      ],
-      "name": "AgreementEligibility_HatClaimedWithAgreement",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint8",
-          "name": "version",
-          "type": "uint8"
-        }
-      ],
-      "name": "Initialized",
-      "type": "event"
-    },
-    {
-      "inputs": [],
-      "name": "ARBITRATOR_HAT",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [],
+      "type": "function",
       "name": "HATS",
+      "inputs": [],
       "outputs": [
-        { "internalType": "contract IHats", "name": "", "type": "address" }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "IMPLEMENTATION",
-      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "OWNER_HAT",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "claimer", "type": "address" }
-      ],
-      "name": "claimerAgreements",
-      "outputs": [
-        { "internalType": "uint256", "name": "agreementId", "type": "uint256" }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "currentAgreement",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "currentAgreementId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" }
-      ],
-      "name": "forgive",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" },
-        { "internalType": "uint256", "name": "", "type": "uint256" }
-      ],
-      "name": "getWearerStatus",
-      "outputs": [
-        { "internalType": "bool", "name": "eligible", "type": "bool" },
-        { "internalType": "bool", "name": "standing", "type": "bool" }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "graceEndsAt",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "hatId",
-      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" }
-      ],
-      "name": "revoke",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "string", "name": "_agreement", "type": "string" },
-        { "internalType": "uint256", "name": "_grace", "type": "uint256" }
-      ],
-      "name": "setAgreement",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
-      ],
-      "name": "setUp",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "signAgreement",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
         {
-          "internalType": "address",
-          "name": "_claimsHatter",
-          "type": "address"
+          "name": "",
+          "type": "address",
+          "internalType": "contract IHats"
         }
       ],
-      "name": "signAgreementAndClaimHat",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
+      "stateMutability": "pure"
     },
     {
+      "type": "function",
+      "name": "IMPLEMENTATION",
       "inputs": [],
-      "name": "version",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "version_",
-      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        { "internalType": "address", "name": "_wearer", "type": "address" }
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
       ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "arbitratorHat",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "claimerAgreements",
+      "inputs": [
+        {
+          "name": "claimer",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "agreementId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "currentAgreement",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "currentAgreementId",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "forgive",
+      "inputs": [
+        {
+          "name": "_wearer",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getWearerStatus",
+      "inputs": [
+        {
+          "name": "_wearer",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "eligible",
+          "type": "bool",
+          "internalType": "bool"
+        },
+        {
+          "name": "standing",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "graceEndsAt",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "hatId",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "ownerHat",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "revoke",
+      "inputs": [
+        {
+          "name": "_wearer",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAgreement",
+      "inputs": [
+        {
+          "name": "_agreement",
+          "type": "string",
+          "internalType": "string"
+        },
+        {
+          "name": "_grace",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setArbitratorHat",
+      "inputs": [
+        {
+          "name": "_newArbitratorHat",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setOwnerHat",
+      "inputs": [
+        {
+          "name": "_newOwnerHat",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setUp",
+      "inputs": [
+        {
+          "name": "_initData",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "signAgreement",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "signAgreementAndClaimHat",
+      "inputs": [
+        {
+          "name": "_claimsHatter",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "version",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "version_",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "wearerStanding",
-      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-      "stateMutability": "view",
-      "type": "function"
+      "inputs": [
+        {
+          "name": "_wearer",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "AgreementEligibility_AgreementSet",
+      "inputs": [
+        {
+          "name": "agreement",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        },
+        {
+          "name": "grace",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AgreementEligibility_AgreementSigned",
+      "inputs": [
+        {
+          "name": "signer",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "agreement",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AgreementEligibility_ArbitratorHatSet",
+      "inputs": [
+        {
+          "name": "newArbitratorHat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AgreementEligibility_HatClaimedWithAgreement",
+      "inputs": [
+        {
+          "name": "claimer",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "hatId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "agreement",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AgreementEligibility_OwnerHatSet",
+      "inputs": [
+        {
+          "name": "newOwnerHat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Initialized",
+      "inputs": [
+        {
+          "name": "version",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AgreementEligibility_HatNotMutable",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "AgreementEligibility_NotArbitrator",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "AgreementEligibility_NotOwner",
+      "inputs": []
     }
   ]
 }

--- a/modules/AgreementEligibility.json
+++ b/modules/AgreementEligibility.json
@@ -98,12 +98,12 @@
     {
       "id": "agreementOwner",
       "name": "Agreement Owner",
-      "criteria": "OWNER_HAT"
+      "criteria": "ownerHat"
     },
     {
       "id": "agreementArbitrator",
       "name": "Agreement Arbitrator",
-      "criteria": "ARBITRATOR_HAT"
+      "criteria": "arbitratorHat"
     }
   ],
   "writeFunctions": [
@@ -210,432 +210,308 @@
   ],
   "abi": [
     {
-      "type": "constructor",
       "inputs": [
-        {
-          "name": "_version",
-          "type": "string",
-          "internalType": "string"
-        }
+        { "internalType": "string", "name": "_version", "type": "string" }
       ],
-      "stateMutability": "nonpayable"
+      "stateMutability": "nonpayable",
+      "type": "constructor"
     },
     {
-      "type": "function",
-      "name": "HATS",
       "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "address",
-          "internalType": "contract IHats"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "IMPLEMENTATION",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "arbitratorHat",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "claimerAgreements",
-      "inputs": [
-        {
-          "name": "claimer",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "agreementId",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "currentAgreement",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "string",
-          "internalType": "string"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "currentAgreementId",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "forgive",
-      "inputs": [
-        {
-          "name": "_wearer",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "getWearerStatus",
-      "inputs": [
-        {
-          "name": "_wearer",
-          "type": "address",
-          "internalType": "address"
-        },
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "eligible",
-          "type": "bool",
-          "internalType": "bool"
-        },
-        {
-          "name": "standing",
-          "type": "bool",
-          "internalType": "bool"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "graceEndsAt",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "hatId",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "ownerHat",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "revoke",
-      "inputs": [
-        {
-          "name": "_wearer",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "setAgreement",
-      "inputs": [
-        {
-          "name": "_agreement",
-          "type": "string",
-          "internalType": "string"
-        },
-        {
-          "name": "_grace",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "setArbitratorHat",
-      "inputs": [
-        {
-          "name": "_newArbitratorHat",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "setOwnerHat",
-      "inputs": [
-        {
-          "name": "_newOwnerHat",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "setUp",
-      "inputs": [
-        {
-          "name": "_initData",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "signAgreement",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "signAgreementAndClaimHat",
-      "inputs": [
-        {
-          "name": "_claimsHatter",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "version",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "string",
-          "internalType": "string"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "version_",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "string",
-          "internalType": "string"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "wearerStanding",
-      "inputs": [
-        {
-          "name": "_wearer",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "event",
-      "name": "AgreementEligibility_AgreementSet",
-      "inputs": [
-        {
-          "name": "agreement",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
-        },
-        {
-          "name": "grace",
-          "type": "uint256",
-          "indexed": false,
-          "internalType": "uint256"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "AgreementEligibility_AgreementSigned",
-      "inputs": [
-        {
-          "name": "signer",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        },
-        {
-          "name": "agreement",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "AgreementEligibility_ArbitratorHatSet",
-      "inputs": [
-        {
-          "name": "newArbitratorHat",
-          "type": "uint256",
-          "indexed": false,
-          "internalType": "uint256"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "AgreementEligibility_HatClaimedWithAgreement",
-      "inputs": [
-        {
-          "name": "claimer",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        },
-        {
-          "name": "hatId",
-          "type": "uint256",
-          "indexed": false,
-          "internalType": "uint256"
-        },
-        {
-          "name": "agreement",
-          "type": "string",
-          "indexed": false,
-          "internalType": "string"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "AgreementEligibility_OwnerHatSet",
-      "inputs": [
-        {
-          "name": "newOwnerHat",
-          "type": "uint256",
-          "indexed": false,
-          "internalType": "uint256"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "Initialized",
-      "inputs": [
-        {
-          "name": "version",
-          "type": "uint8",
-          "indexed": false,
-          "internalType": "uint8"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "error",
       "name": "AgreementEligibility_HatNotMutable",
-      "inputs": []
+      "type": "error"
     },
     {
-      "type": "error",
+      "inputs": [],
       "name": "AgreementEligibility_NotArbitrator",
-      "inputs": []
+      "type": "error"
+    },
+    { "inputs": [], "name": "AgreementEligibility_NotOwner", "type": "error" },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "grace",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSet",
+      "type": "event"
     },
     {
-      "type": "error",
-      "name": "AgreementEligibility_NotOwner",
-      "inputs": []
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSigned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newArbitratorHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_ArbitratorHatSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "claimer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "hatId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_HatClaimedWithAgreement",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newOwnerHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_OwnerHatSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "HATS",
+      "outputs": [
+        { "internalType": "contract IHats", "name": "", "type": "address" }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "IMPLEMENTATION",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "arbitratorHat",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "claimer", "type": "address" }
+      ],
+      "name": "claimerAgreements",
+      "outputs": [
+        { "internalType": "uint256", "name": "agreementId", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreement",
+      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreementId",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_wearer", "type": "address" }
+      ],
+      "name": "forgive",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_wearer", "type": "address" },
+        { "internalType": "uint256", "name": "", "type": "uint256" }
+      ],
+      "name": "getWearerStatus",
+      "outputs": [
+        { "internalType": "bool", "name": "eligible", "type": "bool" },
+        { "internalType": "bool", "name": "standing", "type": "bool" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "graceEndsAt",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "hatId",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ownerHat",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_wearer", "type": "address" }
+      ],
+      "name": "revoke",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "string", "name": "_agreement", "type": "string" },
+        { "internalType": "uint256", "name": "_grace", "type": "uint256" }
+      ],
+      "name": "setAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_newArbitratorHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "setArbitratorHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "_newOwnerHat", "type": "uint256" }
+      ],
+      "name": "setOwnerHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
+      ],
+      "name": "setUp",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "signAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_claimsHatter",
+          "type": "address"
+        }
+      ],
+      "name": "signAgreementAndClaimHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version",
+      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version_",
+      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_wearer", "type": "address" }
+      ],
+      "name": "wearerStanding",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
     }
   ]
 }

--- a/modules/allowlistEligibility.json
+++ b/modules/allowlistEligibility.json
@@ -104,9 +104,7 @@
   ],
   "writeFunctions": [
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "addAccount",
       "label": "Add Account",
       "description": "Add an account to the allowlist",
@@ -121,9 +119,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "addAccounts",
       "label": "Add Accounts",
       "description": "Add multiple accounts to the allowlist",
@@ -137,9 +133,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "removeAccount",
       "label": "Remove Account",
       "description": "Remove an account from the allowlist",
@@ -153,9 +147,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "removeAccountAndBurnHat",
       "label": "Remove and Burn",
       "description": "Remove an account from the allowlist and burn their hat",
@@ -169,9 +161,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "removeAccounts",
       "label": "Remove Accounts",
       "description": "Remove multiple accounts from the allowlist",
@@ -185,9 +175,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListArbitrator"
-      ],
+      "roles": ["allowListArbitrator"],
       "functionName": "setStandingForAccount",
       "label": "Set Standing",
       "description": "Set the standing for an account",
@@ -208,9 +196,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListArbitrator"
-      ],
+      "roles": ["allowListArbitrator"],
       "functionName": "setBadStandingAndBurnHat",
       "label": "Set Bad Standing and Burn Hat",
       "description": "Puts an account in bad standing and burns their hat",
@@ -224,9 +210,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListArbitrator"
-      ],
+      "roles": ["allowListArbitrator"],
       "functionName": "setStandingForAccounts",
       "label": "Set Standings",
       "description": "Set the standing for multiple accounts",
@@ -246,9 +230,7 @@
       ]
     },
     {
-      "roles": [
-        "allowlistOwner"
-      ],
+      "roles": ["allowlistOwner"],
       "functionName": "setOwnerHat",
       "label": "Set Allowlist Owner Hat",
       "description": "Set the id of the allowlist owner hat",
@@ -262,9 +244,7 @@
       ]
     },
     {
-      "roles": [
-        "allowlistOwner"
-      ],
+      "roles": ["allowlistOwner"],
       "functionName": "setArbitratorHat",
       "label": "Set Allowlist Arbitrator Hat",
       "description": "Set the id of the allowlist arbitrator hat",

--- a/modules/allowlistEligibility.json
+++ b/modules/allowlistEligibility.json
@@ -56,7 +56,7 @@
     },
     {
       "chainId": "42220",
-      "block": ""
+      "block": "25623525"
     }
   ],
   "creationArgs": {

--- a/modules/allowlistEligibility.json
+++ b/modules/allowlistEligibility.json
@@ -27,7 +27,6 @@
     "toggle": false,
     "hatter": false
   },
-  "tags": [],
   "implementationAddress": "0x5302757E4CEAD88d52D014113FCC8cb51dd36255",
   "deployments": [
     {

--- a/modules/allowlistEligibility.json
+++ b/modules/allowlistEligibility.json
@@ -13,12 +13,12 @@
   "parameters": [
     {
       "label": "Owner Hat",
-      "functionName": "OWNER_HAT",
+      "functionName": "ownerHat",
       "displayType": "hat"
     },
     {
       "label": "Arbitrator Hat",
-      "functionName": "ARBITRATOR_HAT",
+      "functionName": "arbitratorHat",
       "displayType": "hat"
     }
   ],
@@ -60,7 +60,8 @@
   ],
   "creationArgs": {
     "useHatId": true,
-    "immutable": [
+    "immutable": [],
+    "mutable": [
       {
         "name": "Owner Hat",
         "description": "The hat ID for the owner hat. The wearer(s) of this hat are authorized to add and remove accounts from the allowlist.",
@@ -74,9 +75,7 @@
         "type": "uint256",
         "example": "26959946667150639794667015087019630673637144422540572481103610249216",
         "displayType": "hat"
-      }
-    ],
-    "mutable": [
+      },
       {
         "name": "Accounts",
         "description": "Initial accounts for the allowlist.",
@@ -93,12 +92,12 @@
     {
       "id": "allowListOwner",
       "name": "Allowlist Owner",
-      "criteria": "OWNER_HAT"
+      "criteria": "ownerHat"
     },
     {
       "id": "allowListArbitrator",
       "name": "Allowlist Arbitrator",
-      "criteria": "ARBITRATOR_HAT"
+      "criteria": "arbitratorHat"
     }
   ],
   "writeFunctions": [
@@ -260,11 +259,7 @@
   "abi": [
     {
       "inputs": [
-        {
-          "internalType": "string",
-          "name": "_version",
-          "type": "string"
-        }
+        { "internalType": "string", "name": "_version", "type": "string" }
       ],
       "stateMutability": "nonpayable",
       "type": "constructor"
@@ -276,19 +271,16 @@
     },
     {
       "inputs": [],
+      "name": "AllowlistEligibility_HatNotMutable",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "AllowlistEligibility_NotArbitrator",
       "type": "error"
     },
-    {
-      "inputs": [],
-      "name": "AllowlistEligibility_NotOwner",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "AllowlistEligibility_NotWearer",
-      "type": "error"
-    },
+    { "inputs": [], "name": "AllowlistEligibility_NotOwner", "type": "error" },
+    { "inputs": [], "name": "AllowlistEligibility_NotWearer", "type": "error" },
     {
       "anonymous": false,
       "inputs": [
@@ -384,6 +376,19 @@
       "inputs": [
         {
           "indexed": false,
+          "internalType": "uint256",
+          "name": "newArbitratorHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "ArbitratorHatSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
           "internalType": "uint8",
           "name": "version",
           "type": "uint8"
@@ -393,27 +398,23 @@
       "type": "event"
     },
     {
-      "inputs": [],
-      "name": "ARBITRATOR_HAT",
-      "outputs": [
+      "anonymous": false,
+      "inputs": [
         {
+          "indexed": false,
           "internalType": "uint256",
-          "name": "",
+          "name": "newOwnerHat",
           "type": "uint256"
         }
       ],
-      "stateMutability": "pure",
-      "type": "function"
+      "name": "OwnerHatSet",
+      "type": "event"
     },
     {
       "inputs": [],
       "name": "HATS",
       "outputs": [
-        {
-          "internalType": "contract IHats",
-          "name": "",
-          "type": "address"
-        }
+        { "internalType": "contract IHats", "name": "", "type": "address" }
       ],
       "stateMutability": "pure",
       "type": "function"
@@ -421,36 +422,13 @@
     {
       "inputs": [],
       "name": "IMPLEMENTATION",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "OWNER_HAT",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
       "stateMutability": "pure",
       "type": "function"
     },
     {
       "inputs": [
-        {
-          "internalType": "address",
-          "name": "_account",
-          "type": "address"
-        }
+        { "internalType": "address", "name": "_account", "type": "address" }
       ],
       "name": "addAccount",
       "outputs": [],
@@ -472,53 +450,32 @@
     },
     {
       "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
+        { "internalType": "address", "name": "account", "type": "address" }
       ],
       "name": "allowlist",
       "outputs": [
-        {
-          "internalType": "bool",
-          "name": "eligible",
-          "type": "bool"
-        },
-        {
-          "internalType": "bool",
-          "name": "badStanding",
-          "type": "bool"
-        }
+        { "internalType": "bool", "name": "eligible", "type": "bool" },
+        { "internalType": "bool", "name": "badStanding", "type": "bool" }
       ],
       "stateMutability": "view",
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "arbitratorHat",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
-        {
-          "internalType": "address",
-          "name": "_wearer",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
+        { "internalType": "address", "name": "_wearer", "type": "address" },
+        { "internalType": "uint256", "name": "", "type": "uint256" }
       ],
       "name": "getWearerStatus",
       "outputs": [
-        {
-          "internalType": "bool",
-          "name": "_eligible",
-          "type": "bool"
-        },
-        {
-          "internalType": "bool",
-          "name": "_standing",
-          "type": "bool"
-        }
+        { "internalType": "bool", "name": "_eligible", "type": "bool" },
+        { "internalType": "bool", "name": "_standing", "type": "bool" }
       ],
       "stateMutability": "view",
       "type": "function"
@@ -526,23 +483,20 @@
     {
       "inputs": [],
       "name": "hatId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
       "stateMutability": "pure",
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "ownerHat",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
-        {
-          "internalType": "address",
-          "name": "_account",
-          "type": "address"
-        }
+        { "internalType": "address", "name": "_account", "type": "address" }
       ],
       "name": "removeAccount",
       "outputs": [],
@@ -551,11 +505,7 @@
     },
     {
       "inputs": [
-        {
-          "internalType": "address",
-          "name": "_account",
-          "type": "address"
-        }
+        { "internalType": "address", "name": "_account", "type": "address" }
       ],
       "name": "removeAccountAndBurnHat",
       "outputs": [],
@@ -578,10 +528,19 @@
     {
       "inputs": [
         {
-          "internalType": "address",
-          "name": "_account",
-          "type": "address"
+          "internalType": "uint256",
+          "name": "_newArbitratorHat",
+          "type": "uint256"
         }
+      ],
+      "name": "setArbitratorHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_account", "type": "address" }
       ],
       "name": "setBadStandingAndBurnHat",
       "outputs": [],
@@ -590,16 +549,17 @@
     },
     {
       "inputs": [
-        {
-          "internalType": "address",
-          "name": "_account",
-          "type": "address"
-        },
-        {
-          "internalType": "bool",
-          "name": "_standing",
-          "type": "bool"
-        }
+        { "internalType": "uint256", "name": "_newOwnerHat", "type": "uint256" }
+      ],
+      "name": "setOwnerHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "_account", "type": "address" },
+        { "internalType": "bool", "name": "_standing", "type": "bool" }
       ],
       "name": "setStandingForAccount",
       "outputs": [],
@@ -613,11 +573,7 @@
           "name": "_accounts",
           "type": "address[]"
         },
-        {
-          "internalType": "bool[]",
-          "name": "_standing",
-          "type": "bool[]"
-        }
+        { "internalType": "bool[]", "name": "_standing", "type": "bool[]" }
       ],
       "name": "setStandingForAccounts",
       "outputs": [],
@@ -626,11 +582,7 @@
     },
     {
       "inputs": [
-        {
-          "internalType": "bytes",
-          "name": "_initData",
-          "type": "bytes"
-        }
+        { "internalType": "bytes", "name": "_initData", "type": "bytes" }
       ],
       "name": "setUp",
       "outputs": [],
@@ -640,26 +592,14 @@
     {
       "inputs": [],
       "name": "version",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
+      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
       "stateMutability": "view",
       "type": "function"
     },
     {
       "inputs": [],
       "name": "version_",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
+      "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
       "stateMutability": "view",
       "type": "function"
     }

--- a/modules/deprecatedAgreementEligibility.json
+++ b/modules/deprecatedAgreementEligibility.json
@@ -1,0 +1,558 @@
+{
+  "deprecated": true,
+  "name": "Agreement Eligibility",
+  "details": [
+    "A Hats Protocol eligibility module that a community or organization can use to enable individuals to join the community by signing an agreement."
+  ],
+  "links": [
+    {
+      "label": "GitHub",
+      "link": "https://github.com/Hats-Protocol/agreement-eligibility"
+    }
+  ],
+  "parameters": [
+    {
+      "label": "Current Agreement",
+      "functionName": "currentAgreement",
+      "displayType": "default"
+    },
+    {
+      "label": "Grace Period Ending",
+      "functionName": "graceEndsAt",
+      "displayType": "timestamp"
+    },
+    {
+      "label": "Owner Hat",
+      "functionName": "OWNER_HAT",
+      "displayType": "hat"
+    },
+    {
+      "label": "Arbitrator Hat",
+      "functionName": "ARBITRATOR_HAT",
+      "displayType": "hat"
+    }
+  ],
+  "type": {
+    "eligibility": true,
+    "toggle": false,
+    "hatter": false
+  },
+  "implementationAddress": "0xF6bc6Dd30403e6ff5b3Bebead32B8fce1b753aA1",
+  "deployments": [
+    {
+      "chainId": "11155111",
+      "block": "5279344"
+    },
+    {
+      "chainId": "10",
+      "block": "116516227"
+    },
+    {
+      "chainId": "42161",
+      "block": "194358596"
+    },
+    {
+      "chainId": "100",
+      "block": "33122123"
+    },
+    {
+      "chainId": "42220",
+      "block": "24754861"
+    },
+    {
+      "chainId": "8453",
+      "block": "12327703"
+    },
+    {
+      "chainId": "137",
+      "block": "55094822"
+    }
+  ],
+  "creationArgs": {
+    "useHatId": true,
+    "immutable": [
+      {
+        "name": "Owner Hat",
+        "description": "The hat ID for the owner hat. The wearer(s) of this hat are authorized to update the agreement.",
+        "type": "uint256",
+        "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+        "displayType": "hat"
+      },
+      {
+        "name": "Arbitrator Hat",
+        "description": "The hat ID for the arbitrator hat. The wearer(s) of this hat are authorized to set the standing for accounts.",
+        "type": "uint256",
+        "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+        "displayType": "hat"
+      }
+    ],
+    "mutable": [
+      {
+        "name": "Agreement",
+        "description": "Initial agreement",
+        "type": "string",
+        "example": "ipfs://bafybeih2a5ztsooqtx7hb32oayynxoeiplaqd5llcnezzj2srqgmc2k2da",
+        "displayType": "default"
+      }
+    ]
+  },
+  "customRoles": [
+    {
+      "id": "agreementOwner",
+      "name": "Agreement Owner",
+      "criteria": "OWNER_HAT"
+    },
+    {
+      "id": "agreementArbitrator",
+      "name": "Agreement Arbitrator",
+      "criteria": "ARBITRATOR_HAT"
+    }
+  ],
+  "writeFunctions": [
+    {
+      "roles": ["public"],
+      "functionName": "signAgreementAndClaimHat",
+      "label": "Sign Agreement and Claim",
+      "description": "Sign the current agreement and claim the hat",
+      "primary": true,
+      "args": [
+        {
+          "name": "Claims Hatter",
+          "description": "A Multi Claims Hatter instance with which to perform claiming",
+          "type": "address",
+          "displayType": "default"
+        }
+      ]
+    },
+    {
+      "roles": ["public"],
+      "functionName": "signAgreement",
+      "label": "Sign Agreement",
+      "description": "Sign the current agreement (without claiming the hat)",
+      "args": []
+    },
+    {
+      "roles": ["agreementOwner"],
+      "functionName": "setAgreement",
+      "label": "Set Agreement",
+      "description": "Set a new agreement, with a grace period",
+      "primary": true,
+      "args": [
+        {
+          "name": "Agreement",
+          "description": "The new agreement, as a hash of the agreement plaintext or a link",
+          "type": "string",
+          "displayType": "default"
+        },
+        {
+          "name": "Grace Period",
+          "description": "The new grace period - the time duration for which signers of the existing agreement are still eligible",
+          "type": "uint256",
+          "displayType": "seconds"
+        }
+      ]
+    },
+    {
+      "roles": ["agreementArbitrator"],
+      "functionName": "revoke",
+      "label": "Revoke",
+      "description": "Revoke the wearer's hat and place them in bad standing",
+      "primary": true,
+      "args": [
+        {
+          "name": "Wearer",
+          "description": "The address of the wearer from whom to revoke the hat",
+          "type": "address",
+          "displayType": "default"
+        }
+      ]
+    },
+    {
+      "roles": ["agreementArbitrator"],
+      "functionName": "forgive",
+      "label": "Forgive",
+      "description": "Forgive the wearer's bad standing, allowing them to claim the hat again",
+      "args": [
+        {
+          "name": "Wearer",
+          "description": "The address of the wearer to forgive",
+          "type": "address",
+          "displayType": "default"
+        }
+      ]
+    }
+  ],
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_NotArbitrator",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_NotOwner",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "grace",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSigned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "claimer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "hatId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_HatClaimedWithAgreement",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "ARBITRATOR_HAT",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "HATS",
+      "outputs": [
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "IMPLEMENTATION",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OWNER_HAT",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "claimer",
+          "type": "address"
+        }
+      ],
+      "name": "claimerAgreements",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "agreementId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreement",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreementId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "forgive",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "getWearerStatus",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "standing",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "graceEndsAt",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "hatId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "revoke",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_agreement",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_grace",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
+      ],
+      "name": "setUp",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "signAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_claimsHatter",
+          "type": "address"
+        }
+      ],
+      "name": "signAgreementAndClaimHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version_",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "wearerStanding",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/modules/deprecatedAllowlistEligibility.json
+++ b/modules/deprecatedAllowlistEligibility.json
@@ -1,4 +1,5 @@
 {
+  "deprecated": true,
   "name": "Allowlist Eligibility",
   "details": [
     "A Hats Protocol eligibility module that uses an allowlist to determine eligibility.",
@@ -27,36 +28,39 @@
     "toggle": false,
     "hatter": false
   },
-  "tags": [],
-  "implementationAddress": "0x5302757E4CEAD88d52D014113FCC8cb51dd36255",
+  "implementationAddress": "0xaC208e6668DE569C6ea1db76DeCea70430335Ed5",
   "deployments": [
     {
+      "chainId": "5",
+      "block": "9647259"
+    },
+    {
       "chainId": "11155111",
-      "block": "5906201"
+      "block": "4655298"
     },
     {
       "chainId": "10",
-      "block": "120018916"
+      "block": "109815832"
     },
     {
       "chainId": "137",
-      "block": "56934846"
+      "block": "48560643"
     },
     {
       "chainId": "42161",
-      "block": "210966200"
+      "block": "139432841"
     },
     {
       "chainId": "100",
-      "block": "33953289"
-    },
-    {
-      "chainId": "8453",
-      "block": "14483153"
+      "block": "30405602"
     },
     {
       "chainId": "42220",
-      "block": ""
+      "block": "24755507"
+    },
+    {
+      "chainId": "8453",
+      "block": "12329333"
     }
   ],
   "creationArgs": {
@@ -104,9 +108,7 @@
   ],
   "writeFunctions": [
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "addAccount",
       "label": "Add Account",
       "description": "Add an account to the allowlist",
@@ -121,9 +123,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "addAccounts",
       "label": "Add Accounts",
       "description": "Add multiple accounts to the allowlist",
@@ -137,9 +137,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "removeAccount",
       "label": "Remove Account",
       "description": "Remove an account from the allowlist",
@@ -153,9 +151,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "removeAccountAndBurnHat",
       "label": "Remove and Burn",
       "description": "Remove an account from the allowlist and burn their hat",
@@ -169,9 +165,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListOwner"
-      ],
+      "roles": ["allowListOwner"],
       "functionName": "removeAccounts",
       "label": "Remove Accounts",
       "description": "Remove multiple accounts from the allowlist",
@@ -185,9 +179,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListArbitrator"
-      ],
+      "roles": ["allowListArbitrator"],
       "functionName": "setStandingForAccount",
       "label": "Set Standing",
       "description": "Set the standing for an account",
@@ -208,9 +200,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListArbitrator"
-      ],
+      "roles": ["allowListArbitrator"],
       "functionName": "setBadStandingAndBurnHat",
       "label": "Set Bad Standing and Burn Hat",
       "description": "Puts an account in bad standing and burns their hat",
@@ -224,9 +214,7 @@
       ]
     },
     {
-      "roles": [
-        "allowListArbitrator"
-      ],
+      "roles": ["allowListArbitrator"],
       "functionName": "setStandingForAccounts",
       "label": "Set Standings",
       "description": "Set the standing for multiple accounts",
@@ -242,38 +230,6 @@
           "description": "The standings to set for each account, corresponding to the accounts order",
           "type": "bool[]",
           "displayType": "default"
-        }
-      ]
-    },
-    {
-      "roles": [
-        "allowlistOwner"
-      ],
-      "functionName": "setOwnerHat",
-      "label": "Set Allowlist Owner Hat",
-      "description": "Set the id of the allowlist owner hat",
-      "args": [
-        {
-          "name": "New Allowlist Owner Hat",
-          "description": "The id of the new allowlist owner hat",
-          "type": "uint256",
-          "displayType": "hat"
-        }
-      ]
-    },
-    {
-      "roles": [
-        "allowlistOwner"
-      ],
-      "functionName": "setArbitratorHat",
-      "label": "Set Allowlist Arbitrator Hat",
-      "description": "Set the id of the allowlist arbitrator hat",
-      "args": [
-        {
-          "name": "New Allowlist Arbitrator Hat",
-          "description": "The id of the new allowlist arbitrator hat",
-          "type": "uint256",
-          "displayType": "hat"
         }
       ]
     }


### PR DESCRIPTION
The Agreement Eligibility and Allowlist Eligibility modules have been updated to convert the owner and arbitrator roles to be mutable, ie changeable by the current owner. This will make those modules easier to manage with less need to migrate their state (wearer signature records and allowlist members, respectively) in order to change the hats corresponding to the those roles.

This submission also deprecates the old versions.