### PR TITLE
Update schema for the display type property

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -6,7 +6,7 @@ const moduleCreationArgSchema = z
     description: z.string(),
     type: z.string(),
     example: z.any(),
-    displayType: z.string(),
+    displayType: z.union([z.string(), z.object({ type: z.string() })]),
     optional: z.boolean().optional(),
   })
   .strict();
@@ -16,7 +16,7 @@ const moduleWriteFunctionArgSchema = z
     name: z.string(),
     description: z.string(),
     type: z.string(),
-    displayType: z.string(),
+    displayType: z.union([z.string(), z.object({ type: z.string() })]),
     optional: z.boolean().optional(),
   })
   .strict();
@@ -50,7 +50,7 @@ export const moduleSchema = z
       z.object({
         label: z.string(),
         functionName: z.string(),
-        displayType: z.string(),
+        displayType: z.union([z.string(), z.object({ type: z.string() })]),
       }),
     ),
     type: z.object({


### PR DESCRIPTION
Update the schema for the `displayType` property, according to the discussion in pr #51. 
The proposed change is that the display type property will accept either a `string` or an object with a required `type` property and zero or more additional properties.