### PR TITLE
Update baalStakingEligibility.json

### DIFF
--- a/modules/baalStakingEligibility.json
+++ b/modules/baalStakingEligibility.json
@@ -81,7 +81,7 @@
       },
       {
         "name": "Judge Hat",
-        "description": "The hat that can slash wearers",
+        "description": "The hat that can set wearers' standing, enabling them to be slashed",
         "type": "uint256",
         "example": "26959946667150639794667015087019630673637144422540572481103610249216",
         "displayType": "hat"

--- a/modules/baalStakingEligibility.json
+++ b/modules/baalStakingEligibility.json
@@ -97,7 +97,7 @@
   },
   "customRoles": [
     {
-      "id": "stakingJudge",
+      "id": "baalStakingJudge",
       "name": "Staking Judge",
       "criteria": "judge"
     }
@@ -246,7 +246,7 @@
       ]
     },
     {
-      "roles": ["stakingJudge"],
+      "roles": ["baalStakingJudge"],
       "functionName": "setStanding",
       "label": "Set Wearer Standing",
       "description": "Set a wearer's standing",

--- a/modules/baalStakingEligibility.json
+++ b/modules/baalStakingEligibility.json
@@ -23,7 +23,7 @@
     {
       "label": "Minimum Stake",
       "functionName": "minStake",
-      "displayType": "amountWithDecimals"
+      "displayType": "default"
     },
     {
       "label": "Cooldown Period",


### PR DESCRIPTION
Temporary adjustment to enable the hats app to accept user input for the min stake creation parameter. 

When the app encounters the `amountWithDecimals` display type, it tries to call the token contract to get number of decimals. But this module sets the token address (read from the Baal contract) when its deployed, so the app doesn't know which token contract to call before deployment.

Changing the display type to `default` gets around this by putting the onus on the user to know how many decimals the token has.

This PR also renames the id of the judge role to avoid a collision with the Staking Eligibility module