### PR TITLE
Github action tests update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ env:
   BASE_RPC: https://base.publicnode.com
   PGN_RPC: https://rpc.publicgoods.network
   CELO_RPC: https://forno.celo.org
-  ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+  ETHERSCAN_KEY: HDMPWG86NYEF1Y5KWZU1XI4HZX4SNHFW3B
 
 jobs:
   test:


### PR DESCRIPTION
Use a public Etherscan key in the Github Action tests, in order for it to work with PRs created from forks. Currently the Action uses the repository's secret key. The problem is that Github Secrets are not provided to Actions triggered from forks. The proposed current solution is to use public RPC endpoints and use a public Etherscan key.