### PR TITLE
Update gitcoinPassportEligibility.json

### DIFF
--- a/modules/gitcoinPassportEligibility.json
+++ b/modules/gitcoinPassportEligibility.json
@@ -39,7 +39,7 @@
     "immutable": [
       {
         "name": "Gitcoin Passport Decoder",
-        "description": "The address of the Gitcoin Passport Decoder contract, from which Passport scores are retrieved. You can find the latest deployment here: https://github.com/gitcoinco/passport/blob/main/deployments/onchainInfo.json",
+        "description": "The address of the Gitcoin Passport Decoder contract, from which Passport scores are retrieved. You can find the latest deployment here: [https://docs.passport.xyz/building-with-passport/smart-contracts/contract-reference#decoder-contract-addresses](https://docs.passport.xyz/building-with-passport/smart-contracts/contract-reference#decoder-contract-addresses)",
         "type": "address",
         "example": "0xe53C60F8069C2f0c3a84F9B3DB5cf56f3100ba56",
         "displayType": "default"


### PR DESCRIPTION
Provides a more user friendly way of retrieving the desired decoder address.

Not sure if the URL could be set to a hypertext, but attempting to do so currently by using markdown.