### PR TITLE
Test optimizations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,51 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  SEPOLIA_RPC: https://ethereum-sepolia-rpc.publicnode.com
-  MAINNET_RPC: https://cloudflare-eth.com
-  POLYGON_RPC: wss://polygon.drpc.org
-  OPTIMISM_RPC: https://mainnet.optimism.io
-  ARBITRUM_RPC: https://1rpc.io/arb
-  GNOSIS_RPC: https://gnosis.publicnode.com
-  BASE_RPC: https://mainnet.base.org
-  PGN_RPC: https://rpc.publicgoods.network
-  CELO_RPC: https://forno.celo.org
-  ETHERSCAN_KEY: HDMPWG86NYEF1Y5KWZU1XI4HZX4SNHFW3B
-
 jobs:
-  test:
+  test-fork:
+    if: github.event.pull_request.head.repo.fork == true && github.event.pull_request.head.repo.private == false
+    env:
+      SEPOLIA_RPC: https://ethereum-sepolia-rpc.publicnode.com
+      MAINNET_RPC: https://cloudflare-eth.com
+      POLYGON_RPC: wss://polygon.drpc.org
+      OPTIMISM_RPC: https://mainnet.optimism.io
+      ARBITRUM_RPC: https://1rpc.io/arb
+      GNOSIS_RPC: https://gnosis.publicnode.com
+      BASE_RPC: https://mainnet.base.org
+      CELO_RPC: https://forno.celo.org
+      ETHERSCAN_KEY: HDMPWG86NYEF1Y5KWZU1XI4HZX4SNHFW3B
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.16.1
+      - name: Set up foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Check Format
+        run: yarn prettier . --check
+      - name: Test
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: yarn test
+  test-branch:
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    env:
+      SEPOLIA_RPC: https://sepolia.infura.io/v3/${{ secrets.INFURA_KEY }}
+      MAINNET_RPC: https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
+      POLYGON_RPC: https://polygon-mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
+      OPTIMISM_RPC: https://optimism-mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
+      ARBITRUM_RPC: https://arbitrum-mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
+      GNOSIS_RPC: https://gnosis.publicnode.com
+      BASE_RPC: https://mainnet.base.org
+      CELO_RPC: https://forno.celo.org
+      ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/test/arbitrumDeployments.test.ts
+++ b/test/arbitrumDeployments.test.ts
@@ -156,7 +156,7 @@ describe("Arbitrum deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }

--- a/test/baseDeployments.test.ts
+++ b/test/baseDeployments.test.ts
@@ -156,7 +156,7 @@ describe("Base deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }

--- a/test/celoDeployments.test.ts
+++ b/test/celoDeployments.test.ts
@@ -156,7 +156,7 @@ describe("Celo deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }

--- a/test/gnosisDeployments.test.ts
+++ b/test/gnosisDeployments.test.ts
@@ -156,7 +156,7 @@ describe("Gnosis deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }

--- a/test/mainnetDeployments.test.ts
+++ b/test/mainnetDeployments.test.ts
@@ -156,7 +156,7 @@ describe("Mainnet deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }

--- a/test/optimismDeployments.test.ts
+++ b/test/optimismDeployments.test.ts
@@ -156,7 +156,7 @@ describe("Optimism deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }

--- a/test/polygonDeployments.test.ts
+++ b/test/polygonDeployments.test.ts
@@ -156,7 +156,7 @@ describe("Polygon deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -51,7 +51,7 @@ describe("Schema Validation Tests", () => {
   }, 30000);
 
   test("Test modules ABI", async () => {
-    const lim = RateLimit(3);
+    const lim = RateLimit(1);
     for (const [id, module] of Object.entries(modules)) {
       await lim();
       console.log(`module: ${module.name}`);

--- a/test/sepoliaDeployments.test.ts
+++ b/test/sepoliaDeployments.test.ts
@@ -159,7 +159,7 @@ describe("Sepolia deployments", () => {
 
       if (res === undefined || res.length !== module?.parameters.length) {
         throw new Error(
-          "Error: could not read all the module's parameters from the instance",
+          `Error: could not read all parameters from the instance of module ${module?.name}`,
         );
       }
     }


### PR DESCRIPTION
- The current Github Action Job that does the testing is using public endpoints for all of the chains. The reason for that is because using non-public endpoints requires using Github Secrets, which are not exposed to Actions that are triggered by PRs from forks. The problem is that these public endpoints are not stable, and thus hard to work with. This PR separates the tests into two Jobs - "test-fork" and "test-branch". Each runs the same tests but "test-fork" is using the public endpoints and "test-branch" is using the non-public endpoints. "test-fork" will be triggered only when the PR is from a fork, while "test-branch" will be triggered only when the PR is from a branch on the repo.
- Change the rate in which we hit the Etherscan API to 1 per-second rather than 3 per-second, due to rate limiting issues that were encountered
- Improve some error messages