### PR TITLE
Update Agreement Eligibility to v0.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,14 +40,14 @@ jobs:
   test-branch:
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     env:
-      SEPOLIA_RPC: https://sepolia.infura.io/v3/${{ secrets.INFURA_KEY }}
-      MAINNET_RPC: https://mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
-      POLYGON_RPC: https://polygon-mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
-      OPTIMISM_RPC: https://optimism-mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
-      ARBITRUM_RPC: https://arbitrum-mainnet.infura.io/v3/${{ secrets.INFURA_KEY }}
-      GNOSIS_RPC: https://gnosis.publicnode.com
-      BASE_RPC: https://mainnet.base.org
-      CELO_RPC: https://forno.celo.org
+      SEPOLIA_RPC: ${{ secrets.SEPOLIA_HTTP_PROVIDER }}
+      MAINNET_RPC: ${{ secrets.MAINNET_HTTP_PROVIDER }}
+      POLYGON_RPC: ${{ secrets.POLYGON_HTTP_PROVIDER }}
+      OPTIMISM_RPC: ${{ secrets.OPTIMISM_HTTP_PROVIDER }}
+      ARBITRUM_RPC: ${{ secrets.ARBITRUM_HTTP_PROVIDER }}
+      GNOSIS_RPC: ${{ secrets.GNOSIS_HTTP_PROVIDER }}
+      BASE_RPC: ${{ secrets.BASE_HTTP_PROVIDER }}
+      CELO_RPC: ${{ secrets.CELO_HTTP_PROVIDER }}
       ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
     runs-on: ubuntu-latest
     steps:

--- a/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
+++ b/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
@@ -242,513 +242,511 @@
     }
   ],
   "abi": [
-    [
-      {
-        "inputs": [
-          {
-            "internalType": "string",
-            "name": "_version",
-            "type": "string"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-      },
-      {
-        "inputs": [],
-        "name": "AgreementEligibility_HatNotMutable",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "AgreementEligibility_NotArbitrator",
-        "type": "error"
-      },
-      {
-        "inputs": [],
-        "name": "AgreementEligibility_NotOwner",
-        "type": "error"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "string",
-            "name": "agreement",
-            "type": "string"
-          },
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "grace",
-            "type": "uint256"
-          }
-        ],
-        "name": "AgreementEligibility_AgreementSet",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "signer",
-            "type": "address"
-          },
-          {
-            "indexed": false,
-            "internalType": "string",
-            "name": "agreement",
-            "type": "string"
-          }
-        ],
-        "name": "AgreementEligibility_AgreementSigned",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "newArbitratorHat",
-            "type": "uint256"
-          }
-        ],
-        "name": "AgreementEligibility_ArbitratorHatSet",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "wearer",
-            "type": "address"
-          }
-        ],
-        "name": "AgreementEligibility_Forgiven",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address[]",
-            "name": "wearers",
-            "type": "address[]"
-          }
-        ],
-        "name": "AgreementEligibility_Forgiven",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "claimer",
-            "type": "address"
-          },
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "hatId",
-            "type": "uint256"
-          },
-          {
-            "indexed": false,
-            "internalType": "string",
-            "name": "agreement",
-            "type": "string"
-          }
-        ],
-        "name": "AgreementEligibility_HatClaimedWithAgreement",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "newOwnerHat",
-            "type": "uint256"
-          }
-        ],
-        "name": "AgreementEligibility_OwnerHatSet",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address",
-            "name": "wearer",
-            "type": "address"
-          }
-        ],
-        "name": "AgreementEligibility_Revoked",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "address[]",
-            "name": "wearers",
-            "type": "address[]"
-          }
-        ],
-        "name": "AgreementEligibility_Revoked",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": false,
-            "internalType": "uint8",
-            "name": "version",
-            "type": "uint8"
-          }
-        ],
-        "name": "Initialized",
-        "type": "event"
-      },
-      {
-        "inputs": [],
-        "name": "HATS",
-        "outputs": [
-          {
-            "internalType": "contract IHats",
-            "name": "",
-            "type": "address"
-          }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "IMPLEMENTATION",
-        "outputs": [
-          {
-            "internalType": "address",
-            "name": "",
-            "type": "address"
-          }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "arbitratorHat",
-        "outputs": [
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "claimer",
-            "type": "address"
-          }
-        ],
-        "name": "claimerAgreements",
-        "outputs": [
-          {
-            "internalType": "uint256",
-            "name": "agreementId",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "currentAgreement",
-        "outputs": [
-          {
-            "internalType": "string",
-            "name": "",
-            "type": "string"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "currentAgreementId",
-        "outputs": [
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "_wearer",
-            "type": "address"
-          }
-        ],
-        "name": "forgive",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address[]",
-            "name": "_wearers",
-            "type": "address[]"
-          }
-        ],
-        "name": "forgive",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "_wearer",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "name": "getWearerStatus",
-        "outputs": [
-          {
-            "internalType": "bool",
-            "name": "eligible",
-            "type": "bool"
-          },
-          {
-            "internalType": "bool",
-            "name": "standing",
-            "type": "bool"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "graceEndsAt",
-        "outputs": [
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "hatId",
-        "outputs": [
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "ownerHat",
-        "outputs": [
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address[]",
-            "name": "_wearers",
-            "type": "address[]"
-          }
-        ],
-        "name": "revoke",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "_wearer",
-            "type": "address"
-          }
-        ],
-        "name": "revoke",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "string",
-            "name": "_agreement",
-            "type": "string"
-          },
-          {
-            "internalType": "uint256",
-            "name": "_grace",
-            "type": "uint256"
-          }
-        ],
-        "name": "setAgreement",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "_newArbitratorHat",
-            "type": "uint256"
-          }
-        ],
-        "name": "setArbitratorHat",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "_newOwnerHat",
-            "type": "uint256"
-          }
-        ],
-        "name": "setOwnerHat",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "bytes",
-            "name": "_initData",
-            "type": "bytes"
-          }
-        ],
-        "name": "setUp",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "signAgreement",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "_claimsHatter",
-            "type": "address"
-          }
-        ],
-        "name": "signAgreementAndClaimHat",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version",
-        "outputs": [
-          {
-            "internalType": "string",
-            "name": "",
-            "type": "string"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [],
-        "name": "version_",
-        "outputs": [
-          {
-            "internalType": "string",
-            "name": "",
-            "type": "string"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "_wearer",
-            "type": "address"
-          }
-        ],
-        "name": "wearerStanding",
-        "outputs": [
-          {
-            "internalType": "bool",
-            "name": "",
-            "type": "bool"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      }
-    ]
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_HatNotMutable",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_NotArbitrator",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_NotOwner",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "grace",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSigned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newArbitratorHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_ArbitratorHatSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "wearer",
+          "type": "address"
+        }
+      ],
+      "name": "AgreementEligibility_Forgiven",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address[]",
+          "name": "wearers",
+          "type": "address[]"
+        }
+      ],
+      "name": "AgreementEligibility_Forgiven",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "claimer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "hatId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_HatClaimedWithAgreement",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newOwnerHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_OwnerHatSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "wearer",
+          "type": "address"
+        }
+      ],
+      "name": "AgreementEligibility_Revoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address[]",
+          "name": "wearers",
+          "type": "address[]"
+        }
+      ],
+      "name": "AgreementEligibility_Revoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "HATS",
+      "outputs": [
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "IMPLEMENTATION",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "arbitratorHat",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "claimer",
+          "type": "address"
+        }
+      ],
+      "name": "claimerAgreements",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "agreementId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreement",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreementId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "forgive",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "_wearers",
+          "type": "address[]"
+        }
+      ],
+      "name": "forgive",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "getWearerStatus",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "standing",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "graceEndsAt",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "hatId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ownerHat",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "_wearers",
+          "type": "address[]"
+        }
+      ],
+      "name": "revoke",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "revoke",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_agreement",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_grace",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_newArbitratorHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "setArbitratorHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_newOwnerHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "setOwnerHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
+      ],
+      "name": "setUp",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "signAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_claimsHatter",
+          "type": "address"
+        }
+      ],
+      "name": "signAgreementAndClaimHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version_",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "wearerStanding",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
   ]
 }

--- a/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
+++ b/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
@@ -39,12 +39,12 @@
     "toggle": false,
     "hatter": false
   },
-  "implementationAddress": "0xeC61e2Fca88BBa42B7e251A1A9738d9ad001B08B",
+  "implementationAddress": "0x4F10B9e99ce11f081652646f4b192ed1b812D5Bb",
   "tags": [],
   "deployments": [
     {
       "chainId": "11155111",
-      "block": "6863721"
+      "block": "6871117"
     },
     {
       "chainId": "10",

--- a/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
+++ b/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
@@ -48,31 +48,27 @@
     },
     {
       "chainId": "10",
-      "block": ""
+      "block": "126708838"
     },
     {
       "chainId": "42161",
-      "block": ""
+      "block": "264150811"
     },
     {
       "chainId": "100",
-      "block": ""
+      "block": "36521638"
     },
     {
       "chainId": "42220",
-      "block": ""
+      "block": "28268854"
     },
     {
       "chainId": "8453",
-      "block": ""
+      "block": "21113616"
     },
     {
       "chainId": "137",
-      "block": ""
-    },
-    {
-      "chainId": "1",
-      "block": ""
+      "block": "63077931"
     }
   ],
   "creationArgs": {

--- a/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
+++ b/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
@@ -116,9 +116,7 @@
   ],
   "writeFunctions": [
     {
-      "roles": [
-        "public"
-      ],
+      "roles": ["public"],
       "functionName": "signAgreementAndClaimHat",
       "label": "Sign Agreement and Claim",
       "description": "Sign the current agreement and claim the hat",
@@ -133,18 +131,14 @@
       ]
     },
     {
-      "roles": [
-        "public"
-      ],
+      "roles": ["public"],
       "functionName": "signAgreement",
       "label": "Sign Agreement",
       "description": "Sign the current agreement (without claiming the hat)",
       "args": []
     },
     {
-      "roles": [
-        "agreementOwner"
-      ],
+      "roles": ["agreementOwner"],
       "functionName": "setAgreement",
       "label": "Set Agreement",
       "description": "Set a new agreement, with a grace period",
@@ -165,9 +159,7 @@
       ]
     },
     {
-      "roles": [
-        "agreementArbitrator"
-      ],
+      "roles": ["agreementArbitrator"],
       "functionName": "revoke",
       "label": "Revoke",
       "description": "Revoke the wearer's hat and place them in bad standing",
@@ -182,9 +174,7 @@
       ]
     },
     {
-      "roles": [
-        "agreementArbitrator"
-      ],
+      "roles": ["agreementArbitrator"],
       "functionName": "revoke",
       "label": "Revoke Multiple",
       "description": "Revoke multiple wearers' hats and place them in bad standing",
@@ -199,9 +189,7 @@
       ]
     },
     {
-      "roles": [
-        "agreementArbitrator"
-      ],
+      "roles": ["agreementArbitrator"],
       "functionName": "forgive",
       "label": "Forgive",
       "description": "Forgive the wearer's bad standing, allowing them to claim the hat again",
@@ -215,9 +203,7 @@
       ]
     },
     {
-      "roles": [
-        "agreementArbitrator"
-      ],
+      "roles": ["agreementArbitrator"],
       "functionName": "forgive",
       "label": "Forgive Multiple",
       "description": "Forgive multiple wearers' bad standing, allowing them to claim the hat again",
@@ -231,9 +217,7 @@
       ]
     },
     {
-      "roles": [
-        "agreementOwner"
-      ],
+      "roles": ["agreementOwner"],
       "functionName": "setOwnerHat",
       "label": "Set Agreement Owner Hat",
       "description": "Set the id of the agreement owner hat",
@@ -247,9 +231,7 @@
       ]
     },
     {
-      "roles": [
-        "agreementOwner"
-      ],
+      "roles": ["agreementOwner"],
       "functionName": "setArbitratorHat",
       "label": "Set Agreement Arbitrator Hat",
       "description": "Set the id of the agreement arbitrator hat",

--- a/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
+++ b/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
@@ -1,0 +1,696 @@
+{
+  "id": "haberdasher-labs_agreement-eligibility",
+  "version": "v0.4.0",
+  "name": "Agreement Eligibility",
+  "details": [
+    "A Hats Protocol eligibility module that a community or organization can use to enable individuals to join the community by signing an agreement.",
+    "This version is compatible with module chaining."
+  ],
+  "links": [
+    {
+      "label": "GitHub",
+      "link": "https://github.com/Hats-Protocol/agreement-eligibility"
+    }
+  ],
+  "parameters": [
+    {
+      "label": "Current Agreement",
+      "functionName": "currentAgreement",
+      "displayType": "default"
+    },
+    {
+      "label": "Grace Period Ending",
+      "functionName": "graceEndsAt",
+      "displayType": "timestamp"
+    },
+    {
+      "label": "Owner Hat",
+      "functionName": "ownerHat",
+      "displayType": "hat"
+    },
+    {
+      "label": "Arbitrator Hat",
+      "functionName": "arbitratorHat",
+      "displayType": "hat"
+    }
+  ],
+  "type": {
+    "eligibility": true,
+    "toggle": false,
+    "hatter": false
+  },
+  "implementationAddress": "0xeC61e2Fca88BBa42B7e251A1A9738d9ad001B08B",
+  "tags": [],
+  "deployments": [
+    {
+      "chainId": "11155111",
+      "block": "6863721"
+    },
+    {
+      "chainId": "10",
+      "block": ""
+    },
+    {
+      "chainId": "42161",
+      "block": ""
+    },
+    {
+      "chainId": "100",
+      "block": ""
+    },
+    {
+      "chainId": "42220",
+      "block": ""
+    },
+    {
+      "chainId": "8453",
+      "block": ""
+    },
+    {
+      "chainId": "137",
+      "block": ""
+    },
+    {
+      "chainId": "1",
+      "block": ""
+    }
+  ],
+  "creationArgs": {
+    "useHatId": true,
+    "immutable": [],
+    "mutable": [
+      {
+        "name": "Owner Hat",
+        "description": "The hat ID for the owner hat. The wearer(s) of this hat are authorized to update the agreement.",
+        "type": "uint256",
+        "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+        "displayType": "hat"
+      },
+      {
+        "name": "Arbitrator Hat",
+        "description": "The hat ID for the arbitrator hat. The wearer(s) of this hat are authorized to set the standing for accounts.",
+        "type": "uint256",
+        "example": "26959946667150639794667015087019630673637144422540572481103610249216",
+        "displayType": "hat"
+      },
+      {
+        "name": "Agreement",
+        "description": "Initial agreement",
+        "type": "string",
+        "example": "ipfs://bafybeih2a5ztsooqtx7hb32oayynxoeiplaqd5llcnezzj2srqgmc2k2da",
+        "displayType": "default"
+      }
+    ]
+  },
+  "customRoles": [
+    {
+      "id": "agreementOwner",
+      "name": "Agreement Owner",
+      "criteria": "ownerHat"
+    },
+    {
+      "id": "agreementArbitrator",
+      "name": "Agreement Arbitrator",
+      "criteria": "arbitratorHat"
+    }
+  ],
+  "writeFunctions": [
+    {
+      "roles": [
+        "public"
+      ],
+      "functionName": "signAgreementAndClaimHat",
+      "label": "Sign Agreement and Claim",
+      "description": "Sign the current agreement and claim the hat",
+      "primary": true,
+      "args": [
+        {
+          "name": "Claims Hatter",
+          "description": "A Multi Claims Hatter instance with which to perform claiming",
+          "type": "address",
+          "displayType": "default"
+        }
+      ]
+    },
+    {
+      "roles": [
+        "public"
+      ],
+      "functionName": "signAgreement",
+      "label": "Sign Agreement",
+      "description": "Sign the current agreement (without claiming the hat)",
+      "args": []
+    },
+    {
+      "roles": [
+        "agreementOwner"
+      ],
+      "functionName": "setAgreement",
+      "label": "Set Agreement",
+      "description": "Set a new agreement, with a grace period",
+      "primary": true,
+      "args": [
+        {
+          "name": "Agreement",
+          "description": "The new agreement, as a hash of the agreement plaintext or a link",
+          "type": "string",
+          "displayType": "default"
+        },
+        {
+          "name": "Grace Period",
+          "description": "The new grace period - the time duration for which signers of the existing agreement are still eligible",
+          "type": "uint256",
+          "displayType": "seconds"
+        }
+      ]
+    },
+    {
+      "roles": [
+        "agreementArbitrator"
+      ],
+      "functionName": "revoke",
+      "label": "Revoke",
+      "description": "Revoke the wearer's hat and place them in bad standing",
+      "primary": true,
+      "args": [
+        {
+          "name": "Wearer",
+          "description": "The address of the wearer from whom to revoke the hat",
+          "type": "address",
+          "displayType": "default"
+        }
+      ]
+    },
+    {
+      "roles": [
+        "agreementArbitrator"
+      ],
+      "functionName": "revoke",
+      "label": "Revoke Multiple",
+      "description": "Revoke multiple wearers' hats and place them in bad standing",
+      "primary": true,
+      "args": [
+        {
+          "name": "Wearers",
+          "description": "The addresses of the wearers from whom to revoke the hats",
+          "type": "address[]",
+          "displayType": "default"
+        }
+      ]
+    },
+    {
+      "roles": [
+        "agreementArbitrator"
+      ],
+      "functionName": "forgive",
+      "label": "Forgive",
+      "description": "Forgive the wearer's bad standing, allowing them to claim the hat again",
+      "args": [
+        {
+          "name": "Wearer",
+          "description": "The address of the wearer to forgive",
+          "type": "address",
+          "displayType": "default"
+        }
+      ]
+    },
+    {
+      "roles": [
+        "agreementArbitrator"
+      ],
+      "functionName": "forgive",
+      "label": "Forgive Multiple",
+      "description": "Forgive multiple wearers' bad standing, allowing them to claim the hat again",
+      "args": [
+        {
+          "name": "Wearers",
+          "description": "The addresses of the wearers to forgive",
+          "type": "address[]",
+          "displayType": "default"
+        }
+      ]
+    },
+    {
+      "roles": [
+        "agreementOwner"
+      ],
+      "functionName": "setOwnerHat",
+      "label": "Set Agreement Owner Hat",
+      "description": "Set the id of the agreement owner hat",
+      "args": [
+        {
+          "name": "New Agreement Owner Hat",
+          "description": "The id of the new agreement owner hat",
+          "type": "uint256",
+          "displayType": "hat"
+        }
+      ]
+    },
+    {
+      "roles": [
+        "agreementOwner"
+      ],
+      "functionName": "setArbitratorHat",
+      "label": "Set Agreement Arbitrator Hat",
+      "description": "Set the id of the agreement arbitrator hat",
+      "args": [
+        {
+          "name": "New Agreement Arbitrator Hat",
+          "description": "The id of the new agreement arbitrator hat",
+          "type": "uint256",
+          "displayType": "hat"
+        }
+      ]
+    }
+  ],
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_version",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_HatNotMutable",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_NotArbitrator",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AgreementEligibility_NotOwner",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "grace",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_AgreementSigned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newArbitratorHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_ArbitratorHatSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "claimer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "hatId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "agreement",
+          "type": "string"
+        }
+      ],
+      "name": "AgreementEligibility_HatClaimedWithAgreement",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newOwnerHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgreementEligibility_OwnerHatSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "HATS",
+      "outputs": [
+        {
+          "internalType": "contract IHats",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "IMPLEMENTATION",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "arbitratorHat",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "claimer",
+          "type": "address"
+        }
+      ],
+      "name": "claimerAgreements",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "agreementId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreement",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentAgreementId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "forgive",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "getWearerStatus",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "eligible",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "standing",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "graceEndsAt",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "hatId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ownerHat",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "revoke",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_agreement",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_grace",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_newArbitratorHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "setArbitratorHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_newOwnerHat",
+          "type": "uint256"
+        }
+      ],
+      "name": "setOwnerHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "_initData",
+          "type": "bytes"
+        }
+      ],
+      "name": "setUp",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "signAgreement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_claimsHatter",
+          "type": "address"
+        }
+      ],
+      "name": "signAgreementAndClaimHat",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version_",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_wearer",
+          "type": "address"
+        }
+      ],
+      "name": "wearerStanding",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
+++ b/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
@@ -242,433 +242,513 @@
     }
   ],
   "abi": [
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_version",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "constructor"
-    },
-    {
-      "inputs": [],
-      "name": "AgreementEligibility_HatNotMutable",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "AgreementEligibility_NotArbitrator",
-      "type": "error"
-    },
-    {
-      "inputs": [],
-      "name": "AgreementEligibility_NotOwner",
-      "type": "error"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "agreement",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "grace",
-          "type": "uint256"
-        }
-      ],
-      "name": "AgreementEligibility_AgreementSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "signer",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "agreement",
-          "type": "string"
-        }
-      ],
-      "name": "AgreementEligibility_AgreementSigned",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "newArbitratorHat",
-          "type": "uint256"
-        }
-      ],
-      "name": "AgreementEligibility_ArbitratorHatSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "claimer",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "hatId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "agreement",
-          "type": "string"
-        }
-      ],
-      "name": "AgreementEligibility_HatClaimedWithAgreement",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "newOwnerHat",
-          "type": "uint256"
-        }
-      ],
-      "name": "AgreementEligibility_OwnerHatSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint8",
-          "name": "version",
-          "type": "uint8"
-        }
-      ],
-      "name": "Initialized",
-      "type": "event"
-    },
-    {
-      "inputs": [],
-      "name": "HATS",
-      "outputs": [
-        {
-          "internalType": "contract IHats",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "IMPLEMENTATION",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "arbitratorHat",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "claimer",
-          "type": "address"
-        }
-      ],
-      "name": "claimerAgreements",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "agreementId",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "currentAgreement",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "currentAgreementId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_wearer",
-          "type": "address"
-        }
-      ],
-      "name": "forgive",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_wearer",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "getWearerStatus",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "eligible",
-          "type": "bool"
-        },
-        {
-          "internalType": "bool",
-          "name": "standing",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "graceEndsAt",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "hatId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "ownerHat",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_wearer",
-          "type": "address"
-        }
-      ],
-      "name": "revoke",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_agreement",
-          "type": "string"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_grace",
-          "type": "uint256"
-        }
-      ],
-      "name": "setAgreement",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_newArbitratorHat",
-          "type": "uint256"
-        }
-      ],
-      "name": "setArbitratorHat",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_newOwnerHat",
-          "type": "uint256"
-        }
-      ],
-      "name": "setOwnerHat",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes",
-          "name": "_initData",
-          "type": "bytes"
-        }
-      ],
-      "name": "setUp",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "signAgreement",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_claimsHatter",
-          "type": "address"
-        }
-      ],
-      "name": "signAgreementAndClaimHat",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "version",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "version_",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_wearer",
-          "type": "address"
-        }
-      ],
-      "name": "wearerStanding",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    }
+    [
+      {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "_version",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+      },
+      {
+        "inputs": [],
+        "name": "AgreementEligibility_HatNotMutable",
+        "type": "error"
+      },
+      {
+        "inputs": [],
+        "name": "AgreementEligibility_NotArbitrator",
+        "type": "error"
+      },
+      {
+        "inputs": [],
+        "name": "AgreementEligibility_NotOwner",
+        "type": "error"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "string",
+            "name": "agreement",
+            "type": "string"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "grace",
+            "type": "uint256"
+          }
+        ],
+        "name": "AgreementEligibility_AgreementSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "string",
+            "name": "agreement",
+            "type": "string"
+          }
+        ],
+        "name": "AgreementEligibility_AgreementSigned",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "newArbitratorHat",
+            "type": "uint256"
+          }
+        ],
+        "name": "AgreementEligibility_ArbitratorHatSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "wearer",
+            "type": "address"
+          }
+        ],
+        "name": "AgreementEligibility_Forgiven",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "address[]",
+            "name": "wearers",
+            "type": "address[]"
+          }
+        ],
+        "name": "AgreementEligibility_Forgiven",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "claimer",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "hatId",
+            "type": "uint256"
+          },
+          {
+            "indexed": false,
+            "internalType": "string",
+            "name": "agreement",
+            "type": "string"
+          }
+        ],
+        "name": "AgreementEligibility_HatClaimedWithAgreement",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "newOwnerHat",
+            "type": "uint256"
+          }
+        ],
+        "name": "AgreementEligibility_OwnerHatSet",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "wearer",
+            "type": "address"
+          }
+        ],
+        "name": "AgreementEligibility_Revoked",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "address[]",
+            "name": "wearers",
+            "type": "address[]"
+          }
+        ],
+        "name": "AgreementEligibility_Revoked",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "uint8",
+            "name": "version",
+            "type": "uint8"
+          }
+        ],
+        "name": "Initialized",
+        "type": "event"
+      },
+      {
+        "inputs": [],
+        "name": "HATS",
+        "outputs": [
+          {
+            "internalType": "contract IHats",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "IMPLEMENTATION",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "arbitratorHat",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "claimer",
+            "type": "address"
+          }
+        ],
+        "name": "claimerAgreements",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "agreementId",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "currentAgreement",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "currentAgreementId",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_wearer",
+            "type": "address"
+          }
+        ],
+        "name": "forgive",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address[]",
+            "name": "_wearers",
+            "type": "address[]"
+          }
+        ],
+        "name": "forgive",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_wearer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "name": "getWearerStatus",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "eligible",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "standing",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "graceEndsAt",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "hatId",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "ownerHat",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address[]",
+            "name": "_wearers",
+            "type": "address[]"
+          }
+        ],
+        "name": "revoke",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_wearer",
+            "type": "address"
+          }
+        ],
+        "name": "revoke",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "_agreement",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "_grace",
+            "type": "uint256"
+          }
+        ],
+        "name": "setAgreement",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "_newArbitratorHat",
+            "type": "uint256"
+          }
+        ],
+        "name": "setArbitratorHat",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "_newOwnerHat",
+            "type": "uint256"
+          }
+        ],
+        "name": "setOwnerHat",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "bytes",
+            "name": "_initData",
+            "type": "bytes"
+          }
+        ],
+        "name": "setUp",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "signAgreement",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_claimsHatter",
+            "type": "address"
+          }
+        ],
+        "name": "signAgreementAndClaimHat",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "version",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "version_",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_wearer",
+            "type": "address"
+          }
+        ],
+        "name": "wearerStanding",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      }
+    ]
   ]
 }

--- a/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
+++ b/modules/haberdasher-labs_agreement-eligibility_v0.4.0.json
@@ -69,6 +69,10 @@
     {
       "chainId": "137",
       "block": "63077931"
+    },
+    {
+      "chainId": "1",
+      "block": "21017026"
     }
   ],
   "creationArgs": {


### PR DESCRIPTION
This new version of Agreement Eligibility adds batch versions of the `revoke()` and `forgive()` functions, allowing the arbitrator to take those actions for multiple wearers at once. It also adds events to those functions to enable better/easier data indexing.